### PR TITLE
Bootstrap WatchTower AI monorepo with Django, FastAPI, React

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Django
+DJANGO_SECRET_KEY=changeme
+DJANGO_DEBUG=True
+ALLOWED_HOSTS=*
+
+# DB/Cache
+DATABASE_URL=postgres://app:app@db:5432/epi
+REDIS_URL=redis://redis:6379/0
+
+# CORS
+CORS_ALLOWED_ORIGINS=http://localhost:5173
+
+# MinIO
+MINIO_ENDPOINT=storage:9000
+MINIO_ACCESS_KEY=minio
+MINIO_SECRET_KEY=minio123
+MINIO_BUCKET=watchtower-evidences
+MINIO_USE_SSL=False
+
+# JWT
+JWT_ACCESS_LIFETIME=3600

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+node_modules/
+static/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+up: ; docker compose up -d --build
+down: ; docker compose down
+logs: ; docker compose logs -f --tail=200
+migrate: ; docker compose exec web python manage.py migrate
+createsuperuser: ; docker compose exec web python manage.py createsuperuser
+collectstatic: ; docker compose exec web python manage.py collectstatic --noinput

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# WatchTower AI — Bootstrap
+
+## Stack
+Django/DRF + Celery + Redis + Postgres + MinIO + FastAPI (Inference) + React/Vite
+
+## Setup
+1. Copie `.env.example` para `.env` e ajuste se necessário.
+2. `make up`
+3. `make migrate`
+4. `make createsuperuser`
+
+## Testes rápidos
+- API: `curl http://localhost:8000/api/health`
+- Docs: `http://localhost:8000/api/docs/`
+- JWT: `POST http://localhost:8000/api/auth/token/`
+- Inference: `curl http://localhost:8500/health`
+- Frontend: `http://localhost:5173`

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["gunicorn", "core.wsgi:application", "-b", "0.0.0.0:8000"]

--- a/backend/apps/monitor/apps.py
+++ b/backend/apps/monitor/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MonitorConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.monitor"

--- a/backend/apps/monitor/tasks.py
+++ b/backend/apps/monitor/tasks.py
@@ -1,0 +1,6 @@
+from celery import shared_task
+
+
+@shared_task
+def ping():
+    return "pong"

--- a/backend/apps/monitor/urls.py
+++ b/backend/apps/monitor/urls.py
@@ -1,0 +1,5 @@
+from django.urls import path
+
+from .views import HealthView
+
+urlpatterns = [path("health", HealthView.as_view(), name="health")]

--- a/backend/apps/monitor/views.py
+++ b/backend/apps/monitor/views.py
@@ -1,0 +1,10 @@
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class HealthView(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        return Response({"status": "ok"})

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/backend/core/asgi.py
+++ b/backend/core/asgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+application = get_asgi_application()

--- a/backend/core/celery.py
+++ b/backend/core/celery.py
@@ -1,0 +1,13 @@
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+app = Celery("core")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print(f"Request: {self.request!r}")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -1,0 +1,73 @@
+import os
+from datetime import timedelta
+from pathlib import Path
+
+import environ
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+env = environ.Env()
+environ.Env.read_env(os.path.join(BASE_DIR.parent, "..", ".env"))
+
+SECRET_KEY = env("DJANGO_SECRET_KEY", default="changeme")
+DEBUG = env.bool("DJANGO_DEBUG", default=True)
+ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["*"])
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "corsheaders",
+    "drf_spectacular",
+    "apps.monitor",
+]
+MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+ROOT_URLCONF = "core.urls"
+WSGI_APPLICATION = "core.wsgi.application"
+ASGI_APPLICATION = "core.asgi.application"
+
+DATABASES = {"default": env.db("DATABASE_URL", default="postgres://app:app@db:5432/epi")}
+REDIS_URL = env("REDIS_URL", default="redis://redis:6379/0")
+
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ),
+}
+
+SPECTACULAR_SETTINGS = {"TITLE": "WatchTower AI API", "VERSION": "0.1.0"}
+
+CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=["http://localhost:5173"])
+
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "static"
+
+DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+AWS_S3_ENDPOINT_URL = f"http://{env('MINIO_ENDPOINT','storage:9000')}"
+AWS_ACCESS_KEY_ID = env("MINIO_ACCESS_KEY", default="minio")
+AWS_SECRET_ACCESS_KEY = env("MINIO_SECRET_KEY", default="minio123")
+AWS_STORAGE_BUCKET_NAME = env("MINIO_BUCKET", default="watchtower-evidences")
+AWS_S3_USE_SSL = env.bool("MINIO_USE_SSL", default=False)
+AWS_S3_ADDRESSING_STYLE = "path"
+
+from celery.schedules import crontab  # noqa: F401
+
+CELERY_BROKER_URL = REDIS_URL
+CELERY_RESULT_BACKEND = REDIS_URL
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(seconds=int(env("JWT_ACCESS_LIFETIME", default=3600))),
+}

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from rest_framework_simplejwt.views import TokenObtainPairView
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/auth/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/docs/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="docs",
+    ),
+    path("api/", include("apps.monitor.urls")),
+]

--- a/backend/core/wsgi.py
+++ b/backend/core/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+application = get_wsgi_application()

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main() -> None:
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 88

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,12 @@
+Django==5.0.6
+djangorestframework==3.15.2
+djangorestframework-simplejwt==5.3.1
+django-cors-headers==4.4.0
+drf-spectacular==0.27.2
+django-environ==0.11.2
+psycopg2-binary==2.9.9
+django-storages[boto3]==1.14.4
+boto3==1.34.131
+celery==5.4.0
+redis==5.0.7
+gunicorn==22.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,76 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: epi
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  storage:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    volumes:
+      - minio:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  web:
+    build: ./backend
+    env_file: .env
+    depends_on:
+      - db
+      - redis
+      - storage
+    ports:
+      - "8000:8000"
+    command: gunicorn core.wsgi:application -b 0.0.0.0:8000
+
+  worker:
+    build: ./backend
+    env_file: .env
+    depends_on:
+      - web
+      - redis
+      - db
+      - storage
+    command: celery -A core worker -l INFO
+
+  beat:
+    build: ./backend
+    env_file: .env
+    depends_on:
+      - worker
+    command: celery -A core beat -l INFO
+
+  inference:
+    build: ./inference
+    ports:
+      - "8500:8500"
+    command: uvicorn app:app --host 0.0.0.0 --port 8500 --reload
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "5173:5173"
+    environment:
+      - VITE_API_URL=http://localhost:8000
+    depends_on:
+      - web
+
+volumes:
+  pgdata:
+  minio:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json tsconfig.json vite.config.ts index.html ./
+COPY src ./src
+RUN npm install
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WatchTower AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "watchtower-ai-frontend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.38",
+    "@types/react-dom": "^18.2.17",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import { health } from "./api";
+
+export default function App() {
+  const [data, setData] = useState<any>(null);
+  return (
+    <div style={{ fontFamily: "sans-serif", padding: 24 }}>
+      <h1>WatchTower AI</h1>
+      <button
+        onClick={async () => {
+          setData(await health());
+        }}
+      >
+        Testar API
+      </button>
+      <pre>{data ? JSON.stringify(data, null, 2) : "Clique para testar /api/health"}</pre>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,6 @@
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8000";
+
+export async function health() {
+  const res = await fetch(`${API_URL}/api/health`);
+  return res.json();
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { host: true, port: 5173 },
+});

--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8500"]

--- a/inference/app.py
+++ b/inference/app.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI, File, UploadFile
+
+app = FastAPI(title="WatchTower AI Inference", version="0.1.0")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/infer")
+async def infer(image: UploadFile = File(...)):
+    content = await image.read()
+    _ = len(content)
+    return {"model": "stub", "detections": []}

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+opencv-python-headless==4.10.0.84
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- scaffold Django backend with DRF, JWT, Celery, Redis, Postgres, and MinIO configuration
- add FastAPI inference service with health and inference stubs
- create React/Vite frontend to exercise API health endpoint

## Testing
- `pip install pre-commit black ruff isort` *(failed: Could not connect to proxy)*
- `pre-commit run --all-files` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688eb3c58d1c83269f9377b847c395c9